### PR TITLE
HazelcastCache delegates to FintCache

### DIFF
--- a/src/main/java/no/fint/cache/CacheManager.java
+++ b/src/main/java/no/fint/cache/CacheManager.java
@@ -8,26 +8,9 @@ public interface CacheManager<T extends Serializable> {
 
     Optional<Cache<T>> getCache(String key);
 
-        //         return Optional.ofNullable(caches.get());
-
-
     Cache<T> createCache(String key);
-        /*
-        Cache<T> cache = cacheSupplier.get();
-        caches.put(, cache);
-        return cache;
-
-         */
 
     void remove(String key);
-        /*
-        Optional<Cache<T>> cache = getCache(orgId);
-        cache.ifPresent(c -> {
-            c.flush();
-            caches.remove(orgId);
-        });
-
-         */
 
     boolean hasItems();
 

--- a/src/main/java/no/fint/cache/CacheService.java
+++ b/src/main/java/no/fint/cache/CacheService.java
@@ -28,6 +28,8 @@ public abstract class CacheService<T extends Serializable> {
     @Deprecated
     private ObjectMapper objectMapper;
 
+    private final Comparator<CacheObject<?>> comparator = (first,second) -> Long.compare(first.getLastUpdated(), second.getLastUpdated());
+
     @Autowired
     private CacheManager<T> cacheManager;
 
@@ -128,9 +130,9 @@ public abstract class CacheService<T extends Serializable> {
     }
 
     public boolean supportsAction(String action) {
-        List<String> stringActions = actions.stream().map(Enum::name).collect(Collectors.toList());
-        return stringActions.contains(action);
+        return actions.stream().map(Enum::name).anyMatch(action::equals);
     }
 
     public abstract void onAction(Event event);
+
 }

--- a/src/main/java/no/fint/cache/CacheService.java
+++ b/src/main/java/no/fint/cache/CacheService.java
@@ -28,8 +28,6 @@ public abstract class CacheService<T extends Serializable> {
     @Deprecated
     private ObjectMapper objectMapper;
 
-    private final Comparator<CacheObject<?>> comparator = (first,second) -> Long.compare(first.getLastUpdated(), second.getLastUpdated());
-
     @Autowired
     private CacheManager<T> cacheManager;
 

--- a/src/main/java/no/fint/cache/FintCache.java
+++ b/src/main/java/no/fint/cache/FintCache.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Slf4j
-public class FintCache<T extends Serializable> implements Cache<T> {
+public class FintCache<T extends Serializable> implements Cache<T>, Serializable {
     @Getter
     private CacheMetaData cacheMetaData;
     private Set<CacheObject<T>> cacheObjectList;

--- a/src/main/java/no/fint/cache/FintCache.java
+++ b/src/main/java/no/fint/cache/FintCache.java
@@ -1,5 +1,6 @@
 package no.fint.cache;
 
+import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +34,7 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
             Map<String, CacheObject<T>> cacheObjectMap = getMap(objects);
             if (cacheObjects.isEmpty()) {
                 log.debug("Empty cache, adding all values");
-                cacheObjects = new HashSet<>(cacheObjectMap.values());
+                cacheObjects = ImmutableSet.copyOf(cacheObjectMap.values());
             } else {
                 Set<CacheObject<T>> cacheObjectsCopy = new HashSet<>(cacheObjects);
                 cacheObjects.forEach(cacheObject -> {
@@ -47,7 +48,7 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
                 });
 
                 cacheObjectsCopy.addAll(cacheObjectMap.values());
-                cacheObjects = cacheObjectsCopy;
+                cacheObjects = ImmutableSet.copyOf(cacheObjectsCopy);
             }
 
             updateMetaData();
@@ -59,7 +60,7 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
         Map<String, CacheObject<T>> newObjects = getMap(objects);
         Set<CacheObject<T>> cacheObjectsCopy = new HashSet<>(cacheObjects);
         cacheObjectsCopy.addAll(newObjects.values());
-        cacheObjects = cacheObjectsCopy;
+        cacheObjects = ImmutableSet.copyOf(cacheObjectsCopy);
         updateMetaData();
     }
 

--- a/src/main/java/no/fint/cache/FintCache.java
+++ b/src/main/java/no/fint/cache/FintCache.java
@@ -8,7 +8,10 @@ import no.fint.cache.model.CacheObject;
 
 import java.io.Serializable;
 import java.security.MessageDigest;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -85,10 +88,10 @@ public class FintCache<T extends Serializable> implements Cache<T> {
     }
 
     public List<?> getSourceListSince(long timestamp) {
-        return cacheObjectList.stream().filter(cacheObject ->
-                (cacheObject.getLastUpdated() >= timestamp))
-                .collect(Collectors.toList())
-                .stream().map(CacheObject::getObject)
+        return cacheObjectList
+                .stream()
+                .filter(cacheObject -> (cacheObject.getLastUpdated() >= timestamp))
+                .map(CacheObject::getObject)
                 .collect(Collectors.toList());
     }
 
@@ -103,7 +106,7 @@ public class FintCache<T extends Serializable> implements Cache<T> {
     }
 
     private Map<String, CacheObject<T>> getMap(List<T> list) {
-        return list.stream().map(CacheObject::new).collect(Collectors.toMap(CacheObject::getChecksum, Function.identity(), (a,b)->b));
+        return list.stream().map(CacheObject::new).collect(Collectors.toMap(CacheObject::getChecksum, Function.identity(), (a, b) -> b));
     }
 
     private void flushMetaData() {

--- a/src/main/java/no/fint/cache/HazelcastCache.java
+++ b/src/main/java/no/fint/cache/HazelcastCache.java
@@ -14,7 +14,7 @@ public class HazelcastCache<T extends Serializable> implements Cache<T> {
     private final HazelcastCacheManager<T> manager;
     private final String key;
 
-    public HazelcastCache(HazelcastCacheManager<T> manager, String key) {
+    HazelcastCache(HazelcastCacheManager<T> manager, String key) {
         this.manager = manager;
         this.key = key;
     }

--- a/src/main/java/no/fint/cache/HazelcastCacheManager.java
+++ b/src/main/java/no/fint/cache/HazelcastCacheManager.java
@@ -59,6 +59,6 @@ public class HazelcastCacheManager<T extends Serializable> implements CacheManag
     @PostConstruct
     public void init() {
         caches = hazelcast.getMap("fint-caches");
-        log.info("Connected to Hazelcast {} with service name {}", hazelcast.getName(), caches.getServiceName());
+        log.info("Connected to Hazelcast {} with service name {}, {} caches", hazelcast.getName(), caches.getServiceName(), caches.size());
     }
 }

--- a/src/main/java/no/fint/cache/HazelcastCacheManager.java
+++ b/src/main/java/no/fint/cache/HazelcastCacheManager.java
@@ -1,10 +1,8 @@
 package no.fint.cache;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IList;
-import com.hazelcast.core.ISet;
+import com.hazelcast.core.IMap;
 import lombok.extern.slf4j.Slf4j;
-import no.fint.cache.model.CacheObject;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.annotation.PostConstruct;
@@ -18,28 +16,34 @@ public class HazelcastCacheManager<T extends Serializable> implements CacheManag
     @Autowired
     private HazelcastInstance hazelcast;
 
-    private ISet<String> caches;
+    private IMap<String, Cache<T>> caches;
 
     @Override
     public Optional<Cache<T>> getCache(String key) {
-        if (caches.contains(key)) {
-            return Optional.of(new HazelcastCache<T>(hazelcast.getList(key)));
+        if (caches.containsKey(key)) {
+            return Optional.of(new HazelcastCache<T>(this, key));
         }
         return Optional.empty();
     }
 
+    Cache<T> getCacheInternal(String key) {
+        return caches.getOrDefault(key, new FintCache<>());
+    }
+
     @Override
     public Cache<T> createCache(String key) {
-        IList<CacheObject<T>> cacheObjects = hazelcast.getList(key);
-        log.info("Created cache {} on service {}", cacheObjects.getName(), cacheObjects.getServiceName());
-        caches.add(key);
-        return new HazelcastCache<>(cacheObjects);
+        FintCache<T> result = new FintCache<>();
+        caches.put(key, result);
+        return result;
     }
 
     @Override
     public void remove(String key) {
-        hazelcast.getList(key).destroy();
         caches.remove(key);
+    }
+
+    void replace(String key, Cache<T> replacement) {
+        caches.put(key, replacement);
     }
 
     @Override
@@ -49,12 +53,12 @@ public class HazelcastCacheManager<T extends Serializable> implements CacheManag
 
     @Override
     public Set<String> getKeys() {
-        return caches;
+        return caches.keySet();
     }
 
     @PostConstruct
     public void init() {
-        caches = hazelcast.getSet("fint-caches");
+        caches = hazelcast.getMap("fint-caches");
         log.info("Connected to Hazelcast {} with service name {}", hazelcast.getName(), caches.getServiceName());
     }
 }

--- a/src/main/java/no/fint/cache/model/CacheMetaData.java
+++ b/src/main/java/no/fint/cache/model/CacheMetaData.java
@@ -2,8 +2,10 @@ package no.fint.cache.model;
 
 import lombok.Data;
 
+import java.io.Serializable;
+
 @Data
-public class CacheMetaData {
+public class CacheMetaData implements Serializable {
     private byte[] checksum;
     private long lastUpdated;
     private int cacheCount;

--- a/src/main/java/no/fint/cache/model/CacheObject.java
+++ b/src/main/java/no/fint/cache/model/CacheObject.java
@@ -13,10 +13,10 @@ import java.io.Serializable;
 @Getter
 @EqualsAndHashCode(of = "checksum")
 @ToString
-public class CacheObject<T extends Serializable> implements Serializable {
-    private byte[] checksum;
-    private long lastUpdated;
-    private T object;
+public final class CacheObject<T extends Serializable> implements Serializable {
+    private final byte[] checksum;
+    private final long lastUpdated;
+    private final T object;
 
     public CacheObject(T obj) {
         object = obj;

--- a/src/main/java/no/fint/cache/monitoring/Measurement.java
+++ b/src/main/java/no/fint/cache/monitoring/Measurement.java
@@ -1,12 +1,10 @@
 package no.fint.cache.monitoring;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
-import lombok.Data;
 
 import java.util.concurrent.atomic.DoubleAccumulator;
 import java.util.concurrent.atomic.LongAdder;
 
-@Data
 class Measurement {
 
     private final double initial;

--- a/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
+++ b/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
@@ -93,6 +93,7 @@ class FintCacheIntegrationSpec extends Specification {
 
         then:
         lastUpdated <= System.currentTimeMillis()
+        lastUpdated > 0L
     }
 
     def "Update cache, add new value"() {


### PR DESCRIPTION
This PR should solve the race condition where clients fetching the cache while it's updated is seeing an empty or incomplete cache, as described in #9 

Furthermore, all stream operations are made parallel to increase performance.