### PR TITLE
Performance monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ logging.level.no.fint.cache=DEBUG
 
 ## Performance monitoring
 
-Performance monitoring can be enabled on the implementation of `CacheService`.  
-It is disabled by default, can be enabled by setting the following property: `fint.cache.performance-monitor=true`
+Performance monitoring for the implementations of `CacheService`.  
+It is disabled by default and can be enabled by setting the following property: `fint.cache.performance-monitor=true`
 
 The output from the performance monitoring will be available at these endpoints:  
-* GET `/performance-monitor/keys` - Lists all keys that are included in the performance monitoring
-* GET `/performance-monitor/measurements?keys=<key-name>` - Lists the measurements. If a key query param is provided, it will only return the measurements containing that text
-* DELETE `/performance-monitor/measurements` - Deletes all measurements
+* `GET /performance-monitor/keys` - Lists all keys that are included in the performance monitoring
+* `GET /performance-monitor/measurements?keys=<key-name>` - Lists the measurements. If a key query param is provided, it will only return the measurements containing that text
+* `DELETE `/performance-monitor/measurements` - Deletes all measurements

--- a/README.md
+++ b/README.md
@@ -64,3 +64,14 @@ To add more logging, enable debug log level for FintCache.
 ```properties
 logging.level.no.fint.cache=DEBUG
 ```
+
+
+## Performance monitoring
+
+Performance monitoring can be enabled on the implementation of `CacheService`.  
+It is disabled by default, can be enabled by setting the following property: `fint.cache.performance-monitor=true`
+
+The output from the performance monitoring will be available at these endpoints:  
+* GET `/performance-monitor/keys` - Lists all keys that are included in the performance monitoring
+* GET `/performance-monitor/measurements?keys=<key-name>` - Lists the measurements. If a key query param is provided, it will only return the measurements containing that text
+* DELETE `/performance-monitor/measurements` - Deletes all measurements

--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ It is disabled by default and can be enabled by setting the following property: 
 The output from the performance monitoring will be available at these endpoints:  
 * `GET /performance-monitor/keys` - Lists all keys that are included in the performance monitoring
 * `GET /performance-monitor/measurements?keys=<key-name>` - Lists the measurements. If a key query param is provided, it will only return the measurements containing that text
-* `DELETE `/performance-monitor/measurements` - Deletes all measurements
+* `DELETE /performance-monitor/measurements` - Deletes all measurements

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compile('no.fint:fint-hazelcast:1.1.1')
 
     compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
+    compile('org.aspectj:aspectjweaver:1.9.2')
     compile("org.projectlombok:lombok:${lombokVersion}")
     compile('commons-codec:commons-codec:1.11')
     compile('com.google.guava:guava:24.1-jre')

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testCompile("org.springframework.boot:spring-boot-starter-test:${springBootVersion}")
     testCompile("org.spockframework:spock-spring:${spockSpringVersion}")
     testCompile("org.spockframework:spock-core:${spockSpringVersion}")
+    testCompile('com.github.spock.spring.utils:spock-spring-utils:1.0.0')
 }
 
 task wrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     testCompile("org.springframework.boot:spring-boot-starter-test:${springBootVersion}")
     testCompile("org.spockframework:spock-spring:${spockSpringVersion}")
     testCompile("org.spockframework:spock-core:${spockSpringVersion}")
-    testCompile('com.github.spock.spring.utils:spock-spring-utils:1.0.0')
+    testCompile('no.fint:fint-test-utils:0.0.4')
 }
 
 task wrapper(type: Wrapper) {

--- a/src/main/java/no/fint/cache/annotations/EnableFintCache.java
+++ b/src/main/java/no/fint/cache/annotations/EnableFintCache.java
@@ -1,6 +1,7 @@
 package no.fint.cache.annotations;
 
 import no.fint.cache.config.FintCacheConfig;
+import no.fint.cache.monitoring.PerformanceConfig;
 import org.springframework.context.annotation.Import;
 
 import java.lang.annotation.ElementType;
@@ -10,6 +11,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Import(FintCacheConfig.class)
+@Import({FintCacheConfig.class, PerformanceConfig.class})
 public @interface EnableFintCache {
 }

--- a/src/main/java/no/fint/cache/config/FintCacheConfig.java
+++ b/src/main/java/no/fint/cache/config/FintCacheConfig.java
@@ -6,8 +6,10 @@ import no.fint.cache.HazelcastCacheManager;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
+@EnableScheduling
 public class FintCacheConfig {
 
     @Value("${fint.cache.manager:default}")
@@ -22,5 +24,4 @@ public class FintCacheConfig {
                 return new FintCacheManager<>();
         }
     }
-
 }

--- a/src/main/java/no/fint/cache/config/FintCacheConfig.java
+++ b/src/main/java/no/fint/cache/config/FintCacheConfig.java
@@ -6,10 +6,8 @@ import no.fint.cache.HazelcastCacheManager;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
-@EnableScheduling
 public class FintCacheConfig {
 
     @Value("${fint.cache.manager:default}")

--- a/src/main/java/no/fint/cache/monitoring/Measurement.java
+++ b/src/main/java/no/fint/cache/monitoring/Measurement.java
@@ -2,7 +2,6 @@ package no.fint.cache.monitoring;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import lombok.Data;
-import lombok.Synchronized;
 
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.concurrent.atomic.LongAdder;
@@ -14,7 +13,6 @@ class Measurement {
     private final LongAccumulator min = new LongAccumulator(Long::min, Long.MAX_VALUE);
     private final LongAccumulator max = new LongAccumulator(Long::max, Long.MIN_VALUE);
 
-    @Synchronized
     public void add(long elapsed) {
         count.increment();
         totalTimeUsed.accumulate(elapsed);
@@ -24,7 +22,8 @@ class Measurement {
 
     @JsonGetter
     public long average() {
-        return (totalTimeUsed.get() / count.sum());
+        long countSum = count.sum();
+        return (countSum == 0) ? 0 : (totalTimeUsed.get() / countSum);
     }
 
     @JsonGetter

--- a/src/main/java/no/fint/cache/monitoring/Measurement.java
+++ b/src/main/java/no/fint/cache/monitoring/Measurement.java
@@ -1,0 +1,44 @@
+package no.fint.cache.monitoring;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import lombok.Data;
+import lombok.Synchronized;
+
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
+
+@Data
+class Measurement {
+    private final LongAdder count = new LongAdder();
+    private final LongAccumulator totalTimeUsed = new LongAccumulator(Long::sum, 0L);
+    private final LongAccumulator min = new LongAccumulator(Long::min, Long.MAX_VALUE);
+    private final LongAccumulator max = new LongAccumulator(Long::max, Long.MIN_VALUE);
+
+    @Synchronized
+    public void add(long elapsed) {
+        count.increment();
+        totalTimeUsed.accumulate(elapsed);
+        min.accumulate(elapsed);
+        max.accumulate(elapsed);
+    }
+
+    @JsonGetter
+    public long average() {
+        return (totalTimeUsed.get() / count.sum());
+    }
+
+    @JsonGetter
+    public long count() {
+        return count.sum();
+    }
+
+    @JsonGetter
+    public long min() {
+        return min.get();
+    }
+
+    @JsonGetter
+    public long max() {
+        return max.get();
+    }
+}

--- a/src/main/java/no/fint/cache/monitoring/PerformanceConfig.java
+++ b/src/main/java/no/fint/cache/monitoring/PerformanceConfig.java
@@ -1,0 +1,20 @@
+package no.fint.cache.monitoring;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(name = "fint.cache.performance-monitor", havingValue = "true")
+public class PerformanceConfig {
+
+    @Bean
+    public PerformanceMonitor performanceMonitor() {
+        return new PerformanceMonitor();
+    }
+
+    @Bean
+    public PerformanceMonitorController performanceMonitorController() {
+        return new PerformanceMonitorController(performanceMonitor());
+    }
+}

--- a/src/main/java/no/fint/cache/monitoring/PerformanceMonitor.java
+++ b/src/main/java/no/fint/cache/monitoring/PerformanceMonitor.java
@@ -1,0 +1,42 @@
+package no.fint.cache.monitoring;
+
+import com.google.common.base.Stopwatch;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Aspect
+class PerformanceMonitor {
+
+    @Getter
+    private final ConcurrentHashMap<String, Measurement> measurements = new ConcurrentHashMap<>();
+
+    @Around("execution(* no.fint.cache.CacheService+.*(..))")
+    public Object monitor(ProceedingJoinPoint joinPoint) throws Throwable {
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        try {
+            return joinPoint.proceed();
+        } finally {
+            measurements
+                    .computeIfAbsent(getKey(joinPoint), k -> new Measurement())
+                    .add(stopwatch.stop().elapsed(TimeUnit.MILLISECONDS));
+        }
+    }
+
+    private String getKey(ProceedingJoinPoint proceedingJoinPoint) {
+        String className = proceedingJoinPoint.getTarget().getClass().getName();
+        String methodName = proceedingJoinPoint.getSignature().getName();
+        return String.format("%s.%s", className, methodName);
+    }
+
+    public void clearMeasurements() {
+        measurements.clear();
+    }
+
+}

--- a/src/main/java/no/fint/cache/monitoring/PerformanceMonitorController.java
+++ b/src/main/java/no/fint/cache/monitoring/PerformanceMonitorController.java
@@ -1,0 +1,43 @@
+package no.fint.cache.monitoring;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequestMapping("/performance-monitor")
+public class PerformanceMonitorController {
+
+    private final PerformanceMonitor performanceMonitor;
+
+    PerformanceMonitorController(PerformanceMonitor performanceMonitor) {
+        log.info("Initializing performance monitor");
+        this.performanceMonitor = performanceMonitor;
+    }
+
+    @GetMapping("/keys")
+    public List<String> getKeys() {
+        return performanceMonitor.getMeasurements().keySet().stream().sorted().collect(Collectors.toList());
+    }
+
+    @GetMapping("/measurements")
+    public ConcurrentMap<String, Measurement> getMeasurements(@RequestParam(value = "key", required = false) String key) {
+        if (key == null) {
+            return performanceMonitor.getMeasurements();
+        } else {
+            return performanceMonitor.getMeasurements().entrySet().stream()
+                    .filter(e -> e.getKey().toLowerCase().contains(key.toLowerCase()))
+                    .collect(Collectors.toConcurrentMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+    }
+
+    @DeleteMapping("/measurements")
+    public void clearMeasurements() {
+        performanceMonitor.clearMeasurements();
+    }
+}

--- a/src/main/java/no/fint/cache/monitoring/PerformanceMonitorController.java
+++ b/src/main/java/no/fint/cache/monitoring/PerformanceMonitorController.java
@@ -5,7 +5,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -26,7 +25,7 @@ public class PerformanceMonitorController {
     }
 
     @GetMapping("/measurements")
-    public ConcurrentMap<String, Measurement> getMeasurements(@RequestParam(value = "key", required = false) String key) {
+    public Map<String, Measurement> getMeasurements(@RequestParam(value = "key", required = false) String key) {
         if (key == null) {
             return performanceMonitor.getMeasurements();
         } else {

--- a/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
+++ b/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
@@ -92,7 +92,7 @@ class FintCacheIntegrationSpec extends Specification {
         def lastUpdated = testCacheService.getLastUpdated('rogfk.no')
 
         then:
-        lastUpdated < System.currentTimeMillis()
+        lastUpdated <= System.currentTimeMillis()
     }
 
     def "Update cache, add new value"() {

--- a/src/test/groovy/no/fint/cache/monitoring/MeasurementSpec.groovy
+++ b/src/test/groovy/no/fint/cache/monitoring/MeasurementSpec.groovy
@@ -3,11 +3,13 @@ package no.fint.cache.monitoring
 import spock.lang.Specification
 
 class MeasurementSpec extends Specification {
+    private Measurement measurement
+
+    void setup() {
+        measurement = new Measurement()
+    }
 
     def "Add measurements and get count, min, max and average"() {
-        given:
-        Measurement measurement = new Measurement()
-
         when:
         measurement.add(1)
         measurement.add(2)
@@ -18,5 +20,13 @@ class MeasurementSpec extends Specification {
         measurement.min() == 1
         measurement.max() == 3
         measurement.average() == 2
+    }
+
+    def "Calculate average given 0 count return 0"() {
+        when:
+        def average = measurement.average()
+
+        then:
+        average == 0
     }
 }

--- a/src/test/groovy/no/fint/cache/monitoring/MeasurementSpec.groovy
+++ b/src/test/groovy/no/fint/cache/monitoring/MeasurementSpec.groovy
@@ -1,0 +1,22 @@
+package no.fint.cache.monitoring
+
+import spock.lang.Specification
+
+class MeasurementSpec extends Specification {
+
+    def "Add measurements and get count, min, max and average"() {
+        given:
+        Measurement measurement = new Measurement()
+
+        when:
+        measurement.add(1)
+        measurement.add(2)
+        measurement.add(3)
+
+        then:
+        measurement.count() == 3
+        measurement.min() == 1
+        measurement.max() == 3
+        measurement.average() == 2
+    }
+}

--- a/src/test/groovy/no/fint/cache/monitoring/MeasurementSpec.groovy
+++ b/src/test/groovy/no/fint/cache/monitoring/MeasurementSpec.groovy
@@ -1,17 +1,14 @@
 package no.fint.cache.monitoring
 
+import com.google.common.math.StatsAccumulator
 import spock.lang.Specification
 
 class MeasurementSpec extends Specification {
-    private Measurement measurement
-
-    void setup() {
-        measurement = new Measurement()
-    }
-
     def "Add measurements and get count, min, max and average"() {
+        given:
+        def measurement = new Measurement(1)
+
         when:
-        measurement.add(1)
         measurement.add(2)
         measurement.add(3)
 
@@ -19,14 +16,22 @@ class MeasurementSpec extends Specification {
         measurement.count() == 3
         measurement.min() == 1
         measurement.max() == 3
-        measurement.average() == 2
+        measurement.mean() == 2
     }
 
-    def "Calculate average given 0 count return 0"() {
+    def "Compare with StatsAccumulator"() {
+        given:
+        def acc = new StatsAccumulator()
+
         when:
-        def average = measurement.average()
+        acc.add(1)
+        acc.add(2)
+        acc.add(3)
 
         then:
-        average == 0
+        acc.count() == 3
+        acc.min() == 1
+        acc.max() == 3
+        acc.mean() == 2
     }
 }

--- a/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorControllerSpec.groovy
+++ b/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorControllerSpec.groovy
@@ -1,6 +1,6 @@
 package no.fint.cache.monitoring
 
-import com.github.spock.spring.utils.MockMvcSpecification
+import no.fint.test.utils.MockMvcSpecification
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 

--- a/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorControllerSpec.groovy
+++ b/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorControllerSpec.groovy
@@ -4,18 +4,17 @@ import no.fint.test.utils.MockMvcSpecification
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentMap
-
 class PerformanceMonitorControllerSpec extends MockMvcSpecification {
     private PerformanceMonitorController controller
     private PerformanceMonitor performanceMonitor
     private MockMvc mockMvc
 
     void setup() {
-        ConcurrentMap<String, Measurement> measurements = new ConcurrentHashMap<String, Measurement>()
-        measurements.put('key1', new Measurement())
-        measurements.put('key2', new Measurement())
+        Map<String, Measurement> measurements = [
+                'key1': new Measurement(1),
+                'key2': new Measurement(2)
+        ]
+
         performanceMonitor = Mock(PerformanceMonitor) {
             getMeasurements() >> measurements
         }
@@ -42,8 +41,8 @@ class PerformanceMonitorControllerSpec extends MockMvcSpecification {
 
         then:
         response.andExpect(status().isOk())
-                .andExpect(jsonPath('$.key1.count').value(equalTo(0)))
-                .andExpect(jsonPath('$.key2.count').value(equalTo(0)))
+                .andExpect(jsonPath('$.key1.count').value(equalTo(1)))
+                .andExpect(jsonPath('$.key2.count').value(equalTo(1)))
     }
 
     def "Get measurements with key containing key1"() {
@@ -52,7 +51,7 @@ class PerformanceMonitorControllerSpec extends MockMvcSpecification {
 
         then:
         response.andExpect(status().isOk())
-                .andExpect(jsonPath('$.key1.count').value(equalTo(0)))
+                .andExpect(jsonPath('$.key1.count').value(equalTo(1)))
                 .andExpect(jsonPath('$.key2').doesNotExist())
     }
 

--- a/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorControllerSpec.groovy
+++ b/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorControllerSpec.groovy
@@ -1,0 +1,67 @@
+package no.fint.cache.monitoring
+
+import com.github.spock.spring.utils.MockMvcSpecification
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+
+class PerformanceMonitorControllerSpec extends MockMvcSpecification {
+    private PerformanceMonitorController controller
+    private PerformanceMonitor performanceMonitor
+    private MockMvc mockMvc
+
+    void setup() {
+        ConcurrentMap<String, Measurement> measurements = new ConcurrentHashMap<String, Measurement>()
+        measurements.put('key1', new Measurement())
+        measurements.put('key2', new Measurement())
+        performanceMonitor = Mock(PerformanceMonitor) {
+            getMeasurements() >> measurements
+        }
+        controller = new PerformanceMonitorController(performanceMonitor)
+        mockMvc = standaloneSetup(controller)
+    }
+
+    def "Get all keys"() {
+        when:
+        def response = mockMvc.perform(get('/performance-monitor/keys'))
+
+        then:
+        response
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPathSize('$', 2))
+                .andExpect(jsonPathEquals('$[0]', 'key1'))
+                .andExpect(jsonPathEquals('$[1]', 'key2'))
+    }
+
+    def "Get measurements"() {
+        when:
+        def response = mockMvc.perform(get('/performance-monitor/measurements'))
+
+        then:
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath('$.key1.count').value(equalTo(0)))
+                .andExpect(jsonPath('$.key2.count').value(equalTo(0)))
+    }
+
+    def "Get measurements with key containing key1"() {
+        when:
+        def response = mockMvc.perform(get('/performance-monitor/measurements?key=key1'))
+
+        then:
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath('$.key1.count').value(equalTo(0)))
+                .andExpect(jsonPath('$.key2').doesNotExist())
+    }
+
+    def "Clear measurements"() {
+        when:
+        def response = mockMvc.perform(delete('/performance-monitor/measurements'))
+
+        then:
+        1 * performanceMonitor.clearMeasurements()
+        response.andExpect(status().isOk())
+    }
+}

--- a/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorDisabledSpec.groovy
+++ b/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorDisabledSpec.groovy
@@ -1,0 +1,8 @@
+package no.fint.cache.monitoring
+
+import spock.lang.Specification
+
+class PerformanceMonitorDisabledSpec extends Specification {
+
+
+}

--- a/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorEnabledSpec.groovy
+++ b/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorEnabledSpec.groovy
@@ -1,11 +1,12 @@
 package no.fint.cache.monitoring
 
+
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import spock.lang.Specification
 
-@SpringBootTest(classes = TestApplication)
-class PerformanceMonitorDisabledSpec extends Specification {
+@SpringBootTest(classes = TestApplication, properties = "fint.cache.performance-monitor=true")
+class PerformanceMonitorEnabledSpec extends Specification {
 
     @Autowired(required = false)
     private PerformanceMonitor performanceMonitor
@@ -13,9 +14,9 @@ class PerformanceMonitorDisabledSpec extends Specification {
     @Autowired(required = false)
     private PerformanceMonitorController performanceMonitorController
 
-    def "Disable performance monitor by default"() {
+    def "Enable performance monitor when property set"() {
         expect:
-        !performanceMonitor
-        !performanceMonitorController
+        performanceMonitor
+        performanceMonitorController
     }
 }

--- a/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorSpec.groovy
+++ b/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorSpec.groovy
@@ -1,0 +1,30 @@
+package no.fint.cache.monitoring
+
+import no.fint.cache.utils.TestCacheService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import spock.lang.Specification
+
+@SpringBootTest(classes = TestApplication, properties = "fint.cache.performance-monitor=true")
+class PerformanceMonitorSpec extends Specification {
+
+    @Autowired
+    private TestCacheService testCacheService
+
+    @Autowired
+    private PerformanceMonitor performanceMonitor
+
+    def "Performance monitor"() {
+        when:
+        testCacheService.add('rogfk.no', new ArrayList<String>())
+        def measurements = performanceMonitor.getMeasurements()
+        def measurement = measurements["${TestCacheService.class.getName()}.add"]
+
+        then:
+        measurements.size() == 1
+        measurement.count() == 1
+        measurement.max()
+        measurement.min()
+        measurement.average()
+    }
+}

--- a/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorSpec.groovy
+++ b/src/test/groovy/no/fint/cache/monitoring/PerformanceMonitorSpec.groovy
@@ -25,6 +25,6 @@ class PerformanceMonitorSpec extends Specification {
         measurement.count() == 1
         measurement.max()
         measurement.min()
-        measurement.average()
+        measurement.mean()
     }
 }

--- a/src/test/groovy/no/fint/cache/monitoring/TestApplication.java
+++ b/src/test/groovy/no/fint/cache/monitoring/TestApplication.java
@@ -1,0 +1,10 @@
+package no.fint.cache.monitoring;
+
+import no.fint.cache.annotations.EnableFintCache;
+import no.fint.cache.utils.TestCacheService;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@EnableFintCache
+@SpringBootApplication(scanBasePackageClasses = TestCacheService.class)
+public class TestApplication {
+}

--- a/src/test/groovy/no/fint/cache/utils/TestCacheService.java
+++ b/src/test/groovy/no/fint/cache/utils/TestCacheService.java
@@ -1,12 +1,10 @@
 package no.fint.cache.utils;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import no.fint.cache.CacheService;
 import no.fint.cache.testutils.TestAction;
 import no.fint.event.model.Event;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -22,9 +20,9 @@ public class TestCacheService extends CacheService<String> {
         return super.getOne(orgId, (value) -> value.equals(id));
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void onAction(Event event) {
-        update(event, new TypeReference<List<String>>() {
-        });
+        update(event.getOrgId(), event.getData());
     }
 }


### PR DESCRIPTION
- Easy to enable / disable. It is disabled by default, can be enabled by setting `fint.cache.performance-monitor=true`
- It will log performance numbers for implementations of `no.fint.cache.CacheService`, does not require the services themselves to implement anything
- Provides the results (max, min, average, count and totalTimeUsed) on the endpoint `/performance-monitor/measurements`
- All public methods are logged on the services, but the results can be filtered by adding `?key=`, for instance if I want to look only at the `add` methods I can write the path like this: `/performance-monitor/measurements?key=add`
- The responses will look like this:
```
"no.fint.consumer.models.kontaktperson.KontaktpersonCacheService.populateCacheAll": {
  "count": 1,
  "totalTimeUsed": 8,
  "min": 8,
  "max": 8,
  "average": 8
}
```
- The measurements can be delete with `DELETE /performance-monitor/measurements`