### PR TITLE
Immutable Cache

### DIFF
--- a/src/main/java/no/fint/cache/FintCache.java
+++ b/src/main/java/no/fint/cache/FintCache.java
@@ -1,5 +1,6 @@
 package no.fint.cache;
 
+import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +34,7 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
             Map<String, CacheObject<T>> cacheObjectMap = getMap(objects);
             if (cacheObjects.isEmpty()) {
                 log.debug("Empty cache, adding all values");
-                cacheObjects = new HashSet<>(cacheObjectMap.values());
+                cacheObjects = ImmutableSet.copyOf(cacheObjectMap.values());
             } else {
                 Set<CacheObject<T>> cacheObjectsCopy = new HashSet<>(cacheObjects);
                 cacheObjects.forEach(cacheObject -> {
@@ -47,7 +48,7 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
                 });
 
                 cacheObjectsCopy.addAll(cacheObjectMap.values());
-                cacheObjects = cacheObjectsCopy;
+                cacheObjects = ImmutableSet.copyOf(cacheObjectsCopy);
             }
 
             updateMetaData();
@@ -59,7 +60,7 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
         Map<String, CacheObject<T>> newObjects = getMap(objects);
         Set<CacheObject<T>> cacheObjectsCopy = new HashSet<>(cacheObjects);
         cacheObjectsCopy.addAll(newObjects.values());
-        cacheObjects = cacheObjectsCopy;
+        cacheObjects = ImmutableSet.copyOf(cacheObjectsCopy);
         updateMetaData();
     }
 

--- a/src/main/java/no/fint/cache/model/CacheObject.java
+++ b/src/main/java/no/fint/cache/model/CacheObject.java
@@ -13,10 +13,10 @@ import java.io.Serializable;
 @Getter
 @EqualsAndHashCode(of = "checksum")
 @ToString
-public class CacheObject<T extends Serializable> implements Serializable {
-    private byte[] checksum;
-    private long lastUpdated;
-    private T object;
+public final class CacheObject<T extends Serializable> implements Serializable {
+    private final byte[] checksum;
+    private final long lastUpdated;
+    private final T object;
 
     public CacheObject(T obj) {
         object = obj;


### PR DESCRIPTION
In this PR, cache objects are final, and the cache objects set is immutable.

Guava's `ImmutableSet` focuses on memory efficiency and speed of access, properties that fit well with our purpose for the cache.