### PR TITLE
Pull up populateCache as abstract method.

### DIFF
--- a/src/main/java/no/fint/cache/CacheService.java
+++ b/src/main/java/no/fint/cache/CacheService.java
@@ -133,4 +133,6 @@ public abstract class CacheService<T extends Serializable> {
 
     public abstract void onAction(Event event);
 
+
+    public abstract void populateCache(String orgId);
 }

--- a/src/test/groovy/no/fint/cache/utils/TestCacheService.java
+++ b/src/test/groovy/no/fint/cache/utils/TestCacheService.java
@@ -25,4 +25,9 @@ public class TestCacheService extends CacheService<String> {
     public void onAction(Event event) {
         update(event.getOrgId(), event.getData());
     }
+
+    @Override
+    public void populateCache(String orgId) {
+        
+    }
 }


### PR DESCRIPTION
This is required to enable the consumer to trigger `populateCache` on `REGISTER_ORG_ID`.