### PR TITLE
Throw exception for get operations if cache doesn't exist.

### DIFF
--- a/src/main/java/no/fint/cache/exceptions/CacheNotFoundException.java
+++ b/src/main/java/no/fint/cache/exceptions/CacheNotFoundException.java
@@ -1,0 +1,9 @@
+package no.fint.cache.exceptions;
+
+import java.util.NoSuchElementException;
+
+public class CacheNotFoundException extends NoSuchElementException {
+    public CacheNotFoundException(String s) {
+        super(s);
+    }
+}

--- a/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
+++ b/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
@@ -1,5 +1,6 @@
 package no.fint.cache
 
+import no.fint.cache.exceptions.CacheNotFoundException
 import no.fint.cache.testutils.TestAction
 import no.fint.cache.utils.CacheUri
 import no.fint.cache.utils.TestCacheService
@@ -29,7 +30,6 @@ class FintCacheIntegrationSpec extends Specification {
         then:
         testCacheService.remove('rogfk.no')
         cache != null
-        testCacheService.getAll('rogfk.no').size() == 0
     }
 
     def "Get all values from cache"() {
@@ -43,12 +43,12 @@ class FintCacheIntegrationSpec extends Specification {
         values.contains('test2')
     }
 
-    def "Return empty list when the cache is not present"() {
+    def "Throw exception when the cache is not present"() {
         when:
-        def values = testCacheService.getAll('unknown-org', System.currentTimeMillis())
+        testCacheService.getAll('unknown-org', System.currentTimeMillis())
 
         then:
-        values.size() == 0
+        thrown(CacheNotFoundException)
     }
 
     def "Add items to cache"() {

--- a/src/test/groovy/no/fint/cache/HazelcastCacheIntegrationSpec.groovy
+++ b/src/test/groovy/no/fint/cache/HazelcastCacheIntegrationSpec.groovy
@@ -1,5 +1,6 @@
 package no.fint.cache
 
+import no.fint.cache.exceptions.CacheNotFoundException
 import no.fint.cache.testutils.HazelcastConfiguration
 import no.fint.cache.testutils.TestAction
 import no.fint.cache.utils.CacheUri
@@ -32,7 +33,6 @@ class HazelcastCacheIntegrationSpec extends Specification {
         then:
         cache != null
         cache.size() == 0
-        testCacheService.getAll('rogfk.no').size() == 0
     }
 
     def "Get all values from cache"() {
@@ -46,12 +46,12 @@ class HazelcastCacheIntegrationSpec extends Specification {
         values.contains('test2')
     }
 
-    def "Return empty list when the cache is not present"() {
+    def "Throw exception when the cache is not present"() {
         when:
-        def values = testCacheService.getAll('unknown-org', System.currentTimeMillis())
+        testCacheService.getAll('unknown-org', System.currentTimeMillis())
 
         then:
-        values.size() == 0
+        thrown(CacheNotFoundException)
     }
 
     def "Add items to cache"() {


### PR DESCRIPTION
Instead of falsely returning an empty cache if it doesn't exist, throw `CacheNotFoundException`.

Purpose is that consumer controllers can respond with `503` error if the cache doesn't exist instead of claiming the cache exists and is empty.