### PR TITLE
Add cache size operation.

### DIFF
--- a/src/main/java/no/fint/cache/CacheService.java
+++ b/src/main/java/no/fint/cache/CacheService.java
@@ -68,6 +68,10 @@ public abstract class CacheService<T extends Serializable> {
         return getCache(orgId).map(Cache::getLastUpdated).orElseThrow(() -> new CacheNotFoundException(orgId));
     }
 
+    public long getCacheSize(String orgId) {
+        return getCache(orgId).map(Cache::size).orElseThrow(() -> new CacheNotFoundException(orgId));
+    }
+
     public Optional<Cache<T>> getCache(String orgId) {
         return cacheManager.getCache(CacheUri.create(orgId, model));
     }

--- a/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
+++ b/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
@@ -106,6 +106,14 @@ class FintCacheIntegrationSpec extends Specification {
         lastUpdated > 0L
     }
 
+    def "Get cache size"() {
+        when:
+        def size = testCacheService.getCacheSize('rogfk.no')
+
+        then:
+        size == 2
+    }
+
     def "Update cache, add new value"() {
         when:
         testCacheService.update('rogfk.no', ['test1', 'test2', 'test3'])


### PR DESCRIPTION
Add getCacheSize(orgId) to CacheService.

This should be a (slight) performance improvement as REST controllers start using this instead of retrieveing all items only to count them.