### PR TITLE
Stream cache objects

### DIFF
--- a/src/main/java/no/fint/cache/Cache.java
+++ b/src/main/java/no/fint/cache/Cache.java
@@ -18,9 +18,9 @@ public interface Cache<T extends Serializable> {
 
     void flush();
 
-    Stream<CacheObject<T>> get();
+    Stream<CacheObject<T>> stream();
 
-    Stream<CacheObject<T>> getSince(long timestamp);
+    Stream<CacheObject<T>> streamSince(long timestamp);
 
     long getLastUpdated();
 

--- a/src/main/java/no/fint/cache/CacheService.java
+++ b/src/main/java/no/fint/cache/CacheService.java
@@ -82,7 +82,16 @@ public abstract class CacheService<T extends Serializable> {
     }
 
     public Stream<T> streamAll(String orgId) {
-        return getCache(orgId).orElseThrow(() -> new CacheNotFoundException(orgId)).get().map(CacheObject::getObject);
+        return getCache(orgId).orElseThrow(() -> new CacheNotFoundException(orgId)).stream().map(CacheObject::getObject);
+    }
+
+    public Stream<T> streamSlice(String orgId, int skip, int limit) {
+        return getCache(orgId)
+                .orElseThrow(() -> new CacheNotFoundException(orgId))
+                .stream()
+                .skip(skip)
+                .limit(limit)
+                .map(CacheObject::getObject);
     }
 
     public List<T> getAll(String orgId, long sinceTimestamp) {
@@ -90,7 +99,7 @@ public abstract class CacheService<T extends Serializable> {
     }
 
     public Stream<T> streamSince(String orgId, long sinceTimestamp) {
-        return getCache(orgId).orElseThrow(() -> new CacheNotFoundException(orgId)).getSince(sinceTimestamp).map(CacheObject::getObject);
+        return getCache(orgId).orElseThrow(() -> new CacheNotFoundException(orgId)).streamSince(sinceTimestamp).map(CacheObject::getObject);
     }
 
     public Optional<T> getOne(String orgId, Predicate<T> idFunction) {

--- a/src/main/java/no/fint/cache/CacheService.java
+++ b/src/main/java/no/fint/cache/CacheService.java
@@ -15,6 +15,7 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 public abstract class CacheService<T extends Serializable> {
@@ -77,13 +78,19 @@ public abstract class CacheService<T extends Serializable> {
     }
 
     public List<T> getAll(String orgId) {
-        Cache<T> cache = getCache(orgId).orElseThrow(() -> new CacheNotFoundException(orgId));
-        return cache.get().map(CacheObject::getObject).collect(Collectors.toList());
+        return streamAll(orgId).collect(Collectors.toList());
+    }
+
+    public Stream<T> streamAll(String orgId) {
+        return getCache(orgId).orElseThrow(() -> new CacheNotFoundException(orgId)).get().map(CacheObject::getObject);
     }
 
     public List<T> getAll(String orgId, long sinceTimestamp) {
-        Cache<T> cache = getCache(orgId).orElseThrow(() -> new CacheNotFoundException(orgId));
-        return cache.getSince(sinceTimestamp).map(CacheObject::getObject).collect(Collectors.toList());
+        return streamSince(orgId, sinceTimestamp).collect(Collectors.toList());
+    }
+
+    public Stream<T> streamSince(String orgId, long sinceTimestamp) {
+        return getCache(orgId).orElseThrow(() -> new CacheNotFoundException(orgId)).getSince(sinceTimestamp).map(CacheObject::getObject);
     }
 
     public Optional<T> getOne(String orgId, Predicate<T> idFunction) {

--- a/src/main/java/no/fint/cache/FintCache.java
+++ b/src/main/java/no/fint/cache/FintCache.java
@@ -101,21 +101,21 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
 
     @Override
     public Stream<CacheObject<T>> get() {
-        return cacheObjects.parallelStream();
+        return cacheObjects.stream();
     }
 
     public List<T> getSourceList() {
-        return cacheObjects.parallelStream().map(CacheObject::getObject).collect(Collectors.toList());
+        return cacheObjects.stream().map(CacheObject::getObject).collect(Collectors.toList());
     }
 
     @Override
     public Stream<CacheObject<T>> getSince(long timestamp) {
-        return cacheObjects.parallelStream().filter(cacheObject -> (cacheObject.getLastUpdated() > timestamp));
+        return cacheObjects.stream().filter(cacheObject -> (cacheObject.getLastUpdated() > timestamp));
     }
 
     public List<?> getSourceListSince(long timestamp) {
         return cacheObjects
-                .parallelStream()
+                .stream()
                 .filter(cacheObject -> (cacheObject.getLastUpdated() >= timestamp))
                 .map(CacheObject::getObject)
                 .collect(Collectors.toList());
@@ -175,7 +175,7 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
 
     @Override
     public Stream<CacheObject<T>> filter(Predicate<T> predicate) {
-        return cacheObjects.parallelStream().filter(o -> predicate.test(o.getObject()));
+        return cacheObjects.stream().filter(o -> predicate.test(o.getObject()));
     }
 
     @Override

--- a/src/main/java/no/fint/cache/FintCache.java
+++ b/src/main/java/no/fint/cache/FintCache.java
@@ -100,7 +100,7 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
     }
 
     @Override
-    public Stream<CacheObject<T>> get() {
+    public Stream<CacheObject<T>> stream() {
         return cacheObjects.stream();
     }
 
@@ -109,7 +109,7 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
     }
 
     @Override
-    public Stream<CacheObject<T>> getSince(long timestamp) {
+    public Stream<CacheObject<T>> streamSince(long timestamp) {
         return cacheObjects.stream().filter(cacheObject -> (cacheObject.getLastUpdated() > timestamp));
     }
 

--- a/src/main/java/no/fint/cache/HazelcastCache.java
+++ b/src/main/java/no/fint/cache/HazelcastCache.java
@@ -55,13 +55,13 @@ public class HazelcastCache<T extends Serializable> implements Cache<T> {
     }
 
     @Override
-    public Stream<CacheObject<T>> get() {
-        return manager.getCacheInternal(key).get();
+    public Stream<CacheObject<T>> stream() {
+        return manager.getCacheInternal(key).stream();
     }
 
     @Override
-    public Stream<CacheObject<T>> getSince(long timestamp) {
-        return manager.getCacheInternal(key).getSince(timestamp);
+    public Stream<CacheObject<T>> streamSince(long timestamp) {
+        return manager.getCacheInternal(key).streamSince(timestamp);
     }
 
     @Override

--- a/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
+++ b/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import spock.lang.Specification
 
+import java.util.stream.Collectors
+
 @SpringBootTest(classes = [ FintCacheManager, TestCacheService ])
 class FintCacheIntegrationSpec extends Specification {
     @Autowired
@@ -204,5 +206,16 @@ class FintCacheIntegrationSpec extends Specification {
 
         then:
         result.get() == 'test4'
+    }
+
+    def 'Stream cache slice'() {
+        given:
+        testCacheService.update('rogfk.no', ['test1', 'test2', 'test3', 'test4'])
+
+        when:
+        def result = testCacheService.streamSlice('rogfk.no', 1, 1).collect(Collectors.toList())
+
+        then:
+        result == ['test2']
     }
 }

--- a/src/test/groovy/no/fint/cache/FintCacheSpec.groovy
+++ b/src/test/groovy/no/fint/cache/FintCacheSpec.groovy
@@ -127,7 +127,7 @@ class FintCacheSpec extends Specification {
         defaultCache.update(values)
 
         when:
-        def updatedSince = defaultCache.getSince(System.currentTimeMillis() - 15000)
+        def updatedSince = defaultCache.streamSince(System.currentTimeMillis() - 15000)
 
         then:
         updatedSince.count() == 1
@@ -141,7 +141,7 @@ class FintCacheSpec extends Specification {
         defaultCache.update(values)
 
         when:
-        def updatedSince = defaultCache.getSince(System.currentTimeMillis() + 15000)
+        def updatedSince = defaultCache.streamSince(System.currentTimeMillis() + 15000)
 
         then:
         updatedSince.count() == 0
@@ -155,7 +155,7 @@ class FintCacheSpec extends Specification {
         defaultCache.update(values)
 
         when:
-        def cachedValues = defaultCache.get()
+        def cachedValues = defaultCache.stream()
 
         then:
         cachedValues.findAny().get().getObject() == values.get(0)


### PR DESCRIPTION
Streaming cache objects avoids copying data in some scenarios.  

Also added support for streaming a slice, for pagination.