### PR TITLE
Sorted cache objects

### DIFF
--- a/src/main/java/no/fint/cache/CacheService.java
+++ b/src/main/java/no/fint/cache/CacheService.java
@@ -102,6 +102,15 @@ public abstract class CacheService<T extends Serializable> {
         return getCache(orgId).orElseThrow(() -> new CacheNotFoundException(orgId)).streamSince(sinceTimestamp).map(CacheObject::getObject);
     }
 
+    public Stream<T> streamSliceSince(String orgId, long sinceTimestamp, int skip, int limit) {
+        return getCache(orgId)
+                .orElseThrow(() -> new CacheNotFoundException(orgId))
+                .streamSince(sinceTimestamp)
+                .skip(skip)
+                .limit(limit)
+                .map(CacheObject::getObject);
+    }
+
     public Optional<T> getOne(String orgId, Predicate<T> idFunction) {
         Cache<T> cache = getCache(orgId).orElseThrow(() -> new CacheNotFoundException(orgId));
         return cache.filter(idFunction).max(Comparator.comparingLong(CacheObject::getLastUpdated)).map(CacheObject::getObject);

--- a/src/main/java/no/fint/cache/FintCache.java
+++ b/src/main/java/no/fint/cache/FintCache.java
@@ -58,7 +58,7 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
             });
 
             cacheObjectsCopy.addAll(cacheObjectMap.values());
-            cacheObjects = ImmutableList.copyOf(cacheObjectsCopy);
+            cacheObjects = ImmutableList.sortedCopyOf(Comparator.comparing(CacheObject::getChecksum), cacheObjectsCopy);
         }
 
         updateMetaData();
@@ -82,7 +82,7 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
     private void addInternal(Map<String, CacheObject<T>> newObjects) {
         List<CacheObject<T>> cacheObjectsCopy = new ArrayList<>(cacheObjects);
         cacheObjectsCopy.addAll(newObjects.values());
-        cacheObjects = ImmutableList.copyOf(cacheObjectsCopy);
+        cacheObjects = ImmutableList.sortedCopyOf(Comparator.comparing(CacheObject::getChecksum), cacheObjectsCopy);
         updateMetaData();
     }
 
@@ -133,7 +133,7 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
             int i = iterator.nextIndex();
             CacheObject<T> it = iterator.next();
             digest.update(it.rawChecksum());
-            IntStream.of(it.getHashCodes()).forEach(key -> newIndex.compute(key, (k,v) -> {
+            IntStream.of(it.getHashCodes()).forEach(key -> newIndex.compute(key, (k, v) -> {
                 if (v == null) {
                     return new SingleIndex(i);
                 }
@@ -171,7 +171,9 @@ public class FintCache<T extends Serializable> implements Cache<T>, Serializable
     }
 
     @Override
-    public long volume() { return cacheMetaData.getSize(); }
+    public long volume() {
+        return cacheMetaData.getSize();
+    }
 
     @Override
     public Stream<CacheObject<T>> filter(Predicate<T> predicate) {

--- a/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
+++ b/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
@@ -174,14 +174,14 @@ class FintCacheIntegrationSpec extends Specification {
 
     def "On received event"() {
         given:
-        def event = new Event(orgId: 'rogfk.no', data: ['test1', 'test2', 'test3'])
+        def event = new Event(orgId: 'rogfk.no', data: ['test1', 'test2', 'test3', 'test4'])
 
         when:
         testCacheService.onAction(event)
         def values = testCacheService.getAll('rogfk.no')
 
         then:
-        values.size() == 3
+        values.size() == 4
     }
 
     def 'Update cache with hashcodes'() {
@@ -216,6 +216,6 @@ class FintCacheIntegrationSpec extends Specification {
         def result = testCacheService.streamSlice('rogfk.no', 1, 1).collect(Collectors.toList())
 
         then:
-        result == ['test2']
+        result == ['test4']
     }
 }

--- a/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
+++ b/src/test/groovy/no/fint/cache/FintCacheIntegrationSpec.groovy
@@ -218,4 +218,15 @@ class FintCacheIntegrationSpec extends Specification {
         then:
         result == ['test4']
     }
+
+    def 'Stream cache slice since'() {
+        given:
+        testCacheService.update('rogfk.no', ['test1', 'test2', 'test3', 'test4'])
+
+        when:
+        def result = testCacheService.streamSliceSince('rogfk.no', System.currentTimeMillis() - 500, 1, 1).collect(Collectors.toList())
+
+        then:
+        result == ['test4']
+    }
 }


### PR DESCRIPTION
Sort cache objects by checksum to ensure a deterministic ordering.  In combination with slicing / pagination this is important, as the objects could appear in random order from the source.

Also adds support for pagination in combination with `sinceTimeStamp`.